### PR TITLE
Update brew installation command for macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Or you can install a proper OpenJDK package from your OS vendors.
 In macOS:
 ```
 $ brew tap AdoptOpenJDK/openjdk
-$ brew cask install adoptopenjdk11
+$ brew install --cask adoptopenjdk11
 ```
 
 In Linux (Ubuntu 20.04):


### PR DESCRIPTION
The existing command is outdated and gives the error below:
```
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```